### PR TITLE
Add support for the 'pixelRatio' Dygraphs option.

### DIFF
--- a/src/components/Dygraph/options.js
+++ b/src/components/Dygraph/options.js
@@ -74,6 +74,7 @@ const options = {
   logscale: {type: p.boolean},
   maxNumberWidth: {type: p.number},
   panEdgeFraction: {type: p.number},
+  pixelRatio: {type: p.number},
   pixelsPerLabel: {type: p.number},
   plotter: {type: p.oneOfType([p.func, p.arrayOf(p.func)])},
   plugins: true,


### PR DESCRIPTION
Currently, the React-Dygraphs wrapper does not support the "pixelRatio" parameter, useful for better handling of image exports, specific pixel density devices or for improving performances (see related documentation: https://dygraphs.com/options.html#pixelRatio).

This PR simply adds this new option in :)